### PR TITLE
Allow package to be used on PHP 7.1 or latest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": ">=7.1",
         "doctrine/dbal": "~2.3",
         "phpdocumentor/graphviz": "^1.0",
         "nikic/php-parser":"^2.0|^3.0|^4.0"


### PR DESCRIPTION
It will allow it to install on php 8.x, 9.x etc. but ensure that at least 7.1 is available.

See the above on https://getcomposer.org/doc/04-schema.md#require